### PR TITLE
feat: implement CLI-style chat interface for side panel

### DIFF
--- a/src/ui/views/ChatView.ts
+++ b/src/ui/views/ChatView.ts
@@ -1,0 +1,407 @@
+/**
+ * CLI-style Chat View for Obsius AI Agent
+ * Provides a terminal-like interface for AI chat interactions
+ */
+
+import { ItemView, WorkspaceLeaf } from 'obsidian';
+import ObsiusPlugin from '../../../main';
+
+export const VIEW_TYPE_OBSIUS_CHAT = 'obsius-chat-view';
+
+/**
+ * CLI-style chat view for side panel display
+ */
+export class ChatView extends ItemView {
+  private plugin: ObsiusPlugin;
+  private terminalContainer: HTMLElement;
+  private outputContainer: HTMLElement;
+  private inputLine: HTMLElement;
+  private currentInput: HTMLInputElement;
+  private commandHistory: string[] = [];
+  private historyIndex: number = -1;
+
+  constructor(leaf: WorkspaceLeaf, plugin: ObsiusPlugin) {
+    super(leaf);
+    this.plugin = plugin;
+  }
+
+  getViewType(): string {
+    return VIEW_TYPE_OBSIUS_CHAT;
+  }
+
+  getDisplayText(): string {
+    return 'Obsius CLI';
+  }
+
+  getIcon(): string {
+    return 'terminal';
+  }
+
+  async onOpen(): Promise<void> {
+    console.log('Opening Obsius CLI view...');
+    
+    // Clear existing content
+    const container = this.containerEl.children[1];
+    container.empty();
+
+    // Create terminal container
+    this.terminalContainer = container.createDiv('obsius-terminal');
+    
+    // Create output area
+    this.outputContainer = this.terminalContainer.createDiv('obsius-output');
+    
+    // Show welcome message
+    this.showWelcome();
+    
+    // Create input line
+    this.createInputLine();
+    
+    // Focus input
+    this.currentInput.focus();
+    
+    console.log('Obsius CLI view opened successfully');
+  }
+
+  async onClose(): Promise<void> {
+    console.log('Closing Obsius CLI view...');
+    // Cleanup any resources if needed
+  }
+
+  /**
+   * Show simple welcome message
+   */
+  private showWelcome(): void {
+    this.addOutput('✻ Welcome to Obsius v0.1.0!');
+    this.addOutput('');
+    this.addOutput('Vault: ' + this.getVaultName());
+    this.addOutput('');
+    this.addOutput('Type /help for commands or start chatting.');
+  }
+
+  /**
+   * Get vault name for display
+   */
+  private getVaultName(): string {
+    const vault = this.plugin.app.vault;
+    return vault.getName() || 'Unknown Vault';
+  }
+
+  /**
+   * Create CLI input line
+   */
+  private createInputLine(): void {
+    this.inputLine = this.terminalContainer.createDiv('obsius-input-line');
+    
+    // Prompt indicator
+    const prompt = this.inputLine.createSpan('obsius-prompt');
+    prompt.textContent = this.getPrompt();
+    
+    // Input field
+    this.currentInput = this.inputLine.createEl('input', {
+      type: 'text',
+      cls: 'obsius-input',
+      placeholder: this.getInputPlaceholder()
+    });
+    
+    // Handle input events
+    this.currentInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        this.executeCommand(this.currentInput.value);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        this.navigateHistory(-1);
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        this.navigateHistory(1);
+      } else if (e.key === 'Tab') {
+        e.preventDefault();
+        this.handleTabCompletion();
+      }
+    });
+    
+    // Auto-focus when clicking in terminal
+    this.terminalContainer.addEventListener('click', () => {
+      this.currentInput.focus();
+    });
+  }
+
+  /**
+   * Get command prompt
+   */
+  private getPrompt(): string {
+    return '$ ';
+  }
+
+  /**
+   * Get placeholder text for input
+   */
+  private getInputPlaceholder(): string {
+    const provider = this.getCurrentProvider();
+    const providerName = this.plugin.settings.providers[provider]?.name || 'None';
+    return `obsius (${providerName})`;
+  }
+
+  /**
+   * Execute command
+   */
+  private async executeCommand(command: string): Promise<void> {
+    const trimmedCommand = command.trim();
+    if (!trimmedCommand) return;
+    
+    // Add to history
+    this.commandHistory.unshift(trimmedCommand);
+    this.historyIndex = -1;
+    
+    // Show command in output
+    this.addCommandLine(trimmedCommand);
+    
+    // Clear input
+    this.currentInput.value = '';
+    
+    // Execute command
+    if (trimmedCommand.startsWith('/')) {
+      await this.executeSystemCommand(trimmedCommand);
+    } else {
+      await this.sendChatMessage(trimmedCommand);
+    }
+    
+    // Scroll to bottom
+    this.scrollToBottom();
+  }
+
+  /**
+   * Navigate command history
+   */
+  private navigateHistory(direction: number): void {
+    if (this.commandHistory.length === 0) return;
+    
+    this.historyIndex += direction;
+    
+    if (this.historyIndex < -1) {
+      this.historyIndex = -1;
+      this.currentInput.value = '';
+    } else if (this.historyIndex >= this.commandHistory.length) {
+      this.historyIndex = this.commandHistory.length - 1;
+    }
+    
+    if (this.historyIndex >= 0) {
+      this.currentInput.value = this.commandHistory[this.historyIndex];
+    }
+  }
+
+  /**
+   * Handle tab completion
+   */
+  private handleTabCompletion(): void {
+    const value = this.currentInput.value;
+    const commands = ['/help', '/clear', '/provider', '/settings', '/status'];
+    
+    const matches = commands.filter(cmd => cmd.startsWith(value));
+    if (matches.length === 1) {
+      this.currentInput.value = matches[0] + ' ';
+    } else if (matches.length > 1) {
+      this.addOutput(`Available commands: ${matches.join(', ')}`);
+    }
+  }
+
+  /**
+   * Add command line to output
+   */
+  private addCommandLine(command: string): void {
+    const line = this.outputContainer.createDiv('obsius-command-line');
+    const prompt = line.createSpan('obsius-output-prompt');
+    prompt.textContent = this.getPrompt();
+    const cmd = line.createSpan('obsius-output-command');
+    cmd.textContent = command;
+  }
+
+  /**
+   * Add output line
+   */
+  private addOutput(text: string, type: 'normal' | 'error' | 'success' | 'info' = 'normal'): void {
+    const line = this.outputContainer.createDiv(`obsius-output-line ${type}`);
+    line.textContent = text;
+  }
+
+  /**
+   * Execute system command
+   */
+  private async executeSystemCommand(command: string): Promise<void> {
+    const [cmd, ...args] = command.slice(1).split(' ');
+    
+    switch (cmd) {
+      case 'help':
+        this.showHelp();
+        break;
+      case 'clear':
+        this.clearOutput();
+        break;
+      case 'provider':
+        this.showProviderInfo(args[0]);
+        break;
+      case 'settings':
+        this.openSettings();
+        break;
+      case 'status':
+        this.showStatus();
+        break;
+      default:
+        this.addOutput(`Unknown command: ${command}`, 'error');
+        this.addOutput('Type /help for available commands', 'info');
+    }
+  }
+
+  /**
+   * Send chat message to AI
+   */
+  private async sendChatMessage(message: string): Promise<void> {
+    const provider = this.getCurrentProvider();
+    const config = this.plugin.settings.providers[provider];
+    
+    if (!config?.authenticated) {
+      this.addOutput('Error: No authenticated AI provider available', 'error');
+      this.addOutput('Use /provider to check provider status or /settings to configure', 'info');
+      return;
+    }
+    
+    // Show thinking indicator
+    this.addOutput('🤔 Thinking...', 'info');
+    
+    try {
+      // TODO: Integrate with AgentOrchestrator
+      await this.simulateTypingDelay();
+      this.addOutput("AI integration is still being implemented. This is a placeholder response.", 'info');
+      this.addOutput("Soon I'll be able to help you with your Obsidian vault!");
+      
+    } catch (error) {
+      this.addOutput(`Error: ${error instanceof Error ? error.message : 'Unknown error'}`, 'error');
+    }
+  }
+
+  /**
+   * Show help information
+   */
+  private showHelp(): void {
+    this.addOutput('Commands:');
+    this.addOutput('  /help      Show commands');
+    this.addOutput('  /clear     Clear terminal');
+    this.addOutput('  /provider  Show providers');
+    this.addOutput('  /settings  Open settings');
+    this.addOutput('  /status    Show status');
+    this.addOutput('');
+    this.addOutput('Type any message to chat with AI.');
+  }
+
+  /**
+   * Clear output
+   */
+  private clearOutput(): void {
+    this.outputContainer.empty();
+  }
+
+  /**
+   * Show provider information
+   */
+  private showProviderInfo(providerId?: string): void {
+    if (providerId) {
+      const config = this.plugin.settings.providers[providerId];
+      if (config) {
+        this.addOutput(`Provider: ${config.name}`, 'info');
+        this.addOutput(`Status: ${config.authenticated ? '✅ Connected' : '❌ Not connected'}`);
+        this.addOutput(`Model: ${config.model}`);
+        if (config.lastVerified) {
+          this.addOutput(`Last verified: ${new Date(config.lastVerified).toLocaleString()}`);
+        }
+      } else {
+        this.addOutput(`Provider '${providerId}' not found`, 'error');
+      }
+    } else {
+      this.addOutput('Available providers:', 'info');
+      for (const [id, config] of Object.entries(this.plugin.settings.providers)) {
+        const status = config.authenticated ? '✅' : '❌';
+        this.addOutput(`  ${id}: ${config.name} ${status}`);
+      }
+    }
+  }
+
+  /**
+   * Open settings
+   */
+  private openSettings(): void {
+    (this.plugin.app as any).setting.open();
+    (this.plugin.app as any).setting.openTabById('obsius');
+    this.addOutput('Settings opened', 'success');
+  }
+
+  /**
+   * Show status
+   */
+  private showStatus(): void {
+    const currentProvider = this.getCurrentProvider();
+    const config = this.plugin.settings.providers[currentProvider];
+    
+    this.addOutput('System Status:', 'info');
+    this.addOutput(`Current provider: ${config?.name || 'None'}`);
+    this.addOutput(`Authentication: ${config?.authenticated ? '✅ Connected' : '❌ Not connected'}`);
+    this.addOutput(`Command history: ${this.commandHistory.length} entries`);
+    
+    const stats = this.plugin.toolRegistry?.getStats();
+    if (stats) {
+      this.addOutput(`Tools available: ${stats.enabled}`);
+    }
+  }
+
+  /**
+   * Simulate typing delay for demo purposes
+   */
+  private simulateTypingDelay(): Promise<void> {
+    return new Promise(resolve => {
+      setTimeout(resolve, 1000 + Math.random() * 1000);
+    });
+  }
+
+  /**
+   * Scroll to bottom of terminal
+   */
+  private scrollToBottom(): void {
+    this.terminalContainer.scrollTop = this.terminalContainer.scrollHeight;
+  }
+
+  /**
+   * Update prompt when provider changes
+   */
+  private updatePrompt(): void {
+    const promptEl = this.inputLine?.querySelector('.obsius-prompt');
+    if (promptEl) {
+      promptEl.textContent = this.getPrompt();
+    }
+    
+    // Update placeholder
+    if (this.currentInput) {
+      this.currentInput.placeholder = this.getInputPlaceholder();
+    }
+  }
+
+  /**
+   * Get the currently selected provider
+   */
+  public getCurrentProvider(): string {
+    return this.plugin.settings.defaultProvider;
+  }
+
+  /**
+   * Refresh provider options (called when providers are updated)
+   */
+  public refreshProviders(): void {
+    // Update prompt with new provider info
+    this.updatePrompt();
+  }
+
+  /**
+   * Focus input for external access
+   */
+  public focusInput(): void {
+    this.currentInput?.focus();
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -366,6 +366,165 @@
 }
 
 /* ====================================================================== */
+/* CLI Terminal Styles */
+/* ====================================================================== */
+
+/* Override Obsidian's default view-content padding for terminal */
+.workspace-leaf-content .view-content:has(.obsius-terminal) {
+  padding: 0;
+}
+
+.obsius-terminal {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--background-primary);
+  font-family: var(--font-monospace);
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text-normal);
+  overflow: hidden;
+  border-left: 1px solid var(--background-modifier-border);
+}
+
+/* Terminal Output Area */
+.obsius-output {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 12px;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  font-family: var(--font-monospace);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.obsius-welcome {
+  margin-bottom: 20px;
+}
+
+.obsius-welcome pre {
+  color: var(--interactive-accent);
+  font-weight: bold;
+  margin: 0;
+  font-family: var(--font-monospace);
+  line-height: 1.2;
+  white-space: pre;
+  font-size: 13px;
+}
+
+/* Claude Code style boxes */
+.obsius-welcome-box,
+.obsius-prompt-box {
+  font-family: var(--font-monospace);
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text-normal);
+  white-space: pre;
+  margin: 8px 0;
+  padding: 0;
+}
+
+.obsius-welcome-box {
+  color: var(--interactive-accent);
+  font-weight: normal;
+}
+
+.obsius-command-line {
+  margin: 8px 0;
+  display: block;
+  font-family: var(--font-monospace);
+  line-height: 1.4;
+}
+
+.obsius-output-prompt {
+  color: var(--interactive-accent);
+  font-weight: bold;
+  display: inline;
+}
+
+.obsius-output-command {
+  color: var(--text-normal);
+  display: inline;
+  margin-left: 4px;
+}
+
+.obsius-output-line {
+  margin: 4px 0;
+  word-wrap: break-word;
+  font-family: var(--font-monospace);
+  font-size: 13px;
+}
+
+.obsius-output-line.error {
+  color: var(--text-error);
+}
+
+.obsius-output-line.success {
+  color: var(--color-green);
+}
+
+.obsius-output-line.info {
+  color: var(--text-accent);
+}
+
+/* Terminal Input Line */
+.obsius-input-line {
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+  border-top: 1px solid var(--background-modifier-border);
+  background: var(--background-primary);
+  flex-shrink: 0;
+}
+
+.obsius-prompt {
+  color: var(--interactive-accent);
+  font-weight: bold;
+  margin-right: 8px;
+  flex-shrink: 0;
+  font-family: var(--font-monospace);
+}
+
+.obsius-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text-normal);
+  font-family: var(--font-monospace);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.obsius-input::placeholder {
+  color: var(--text-muted);
+}
+
+/* Terminal scrollbar styling */
+.obsius-output::-webkit-scrollbar {
+  width: 8px;
+}
+
+.obsius-output::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.obsius-output::-webkit-scrollbar-thumb {
+  background: var(--background-modifier-border);
+  border-radius: 4px;
+}
+
+.obsius-output::-webkit-scrollbar-thumb:hover {
+  background: var(--background-modifier-border-hover);
+}
+
+/* Terminal selection styling */
+.obsius-terminal ::selection {
+  background: var(--text-selection);
+}
+
+/* ====================================================================== */
 /* Accessibility */
 /* ====================================================================== */
 


### PR DESCRIPTION
## Summary

- Implement CLI-style ChatView with terminal interface in right sidebar
- Add CLI command processing with history navigation and tab completion
- Create clean welcome message with version and vault information
- Integrate chat view with ribbon icon and command palette
- Apply terminal styling with monospace fonts and proper color theming
- Override Obsidian's default view padding for clean CLI appearance
- Add subtle left border for visual separation in sidebar

## Features Implemented

- **ChatView Component**: ItemView-based side panel with terminal-like interface
- **CLI Commands**: Built-in commands like `/help`, `/clear`, `/provider`, `/settings`, `/status`
- **Command History**: Arrow key navigation through previous commands
- **Tab Completion**: Auto-complete for system commands
- **Provider Integration**: Display current AI provider in input placeholder
- **Terminal Styling**: Monospace fonts, proper line heights, and theme-aware colors
- **Clean Layout**: Removed excessive padding and added subtle border

## UI/UX Improvements

- Simple welcome message with version and vault name
- Clean `$ ` prompt similar to Claude Code terminal
- Provider information shown in placeholder text
- Responsive design optimized for narrow sidebar width
- Proper scrollbar styling and text selection handling

## Technical Details

- Extends Obsidian's ItemView for proper sidebar integration
- Uses CSS custom properties for theme compatibility
- Implements keyboard shortcuts (Enter, Arrow keys, Tab)
- Auto-focus management for seamless CLI experience
- Terminal output area with proper text wrapping

## Test Plan

- [ ] Open chat view via ribbon icon
- [ ] Test basic commands (`/help`, `/clear`, `/status`)
- [ ] Verify command history navigation with arrow keys
- [ ] Check tab completion functionality
- [ ] Confirm provider information display
- [ ] Test in both light and dark themes
- [ ] Verify sidebar resizing behavior

🤖 Generated with [Claude Code](https://claude.ai/code)